### PR TITLE
fix: replace deprecated gradle-build-action with gradle/actions/setup-gradle in release job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,7 @@ jobs:
           distribution: 'adopt'
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@ac2d340dc04d9e1113182899e983b5400c17cda1 # v3.5.0
+        uses: gradle/actions/setup-gradle@39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f # v6.0.1
         with:
           gradle-home-cache-cleanup: true
       - name: Login to GitHub Container Registry


### PR DESCRIPTION
## Root Cause

The `release` job used `gradle/gradle-build-action@v3.5.0` (the old/deprecated action) while the `build_linux` job already used the newer `gradle/actions/setup-gradle@v6.0.1`.

When `gradle-home-cache-cleanup: true` is set, the old action provisions Gradle 9.x to perform cache cleanup. In Gradle 9, the `removeUnusedEntriesOlderThan` property became **write-only**, so the cleanup init script fails trying to read it:

```
Cannot get the value of write-only property 'removeUnusedEntriesOlderThan'
for object of type org.gradle.api.internal.cache.DefaultCacheConfigurations$DefaultCacheResourceConfiguration.
BUILD FAILED in 6s
```

## Fix

Replace `gradle/gradle-build-action@ac2d340dc04d9e1113182899e983b5400c17cda1` with `gradle/actions/setup-gradle@39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f` (v6.0.1) in the `release` job — consistent with what `build_linux` already uses and compatible with Gradle 9.x.