### PR TITLE
Switch coverage reporting from Coveralls to Codecov

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,12 +29,13 @@ jobs:
         with:
           gradle-home-cache-cleanup: true
       - name: Build
-        env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-          CI_NAME: github-actions
-          CI_JOB_ID: ${{ github.run_id }}
-          CI_PULL_REQUEST: ${{ github.event.pull_request.number }}
-        run: ./gradlew build coveralls
+        run: ./gradlew build jacocoTestReport
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: '**/build/reports/jacoco/test/jacocoTestReport.xml'
+          fail_ci_if_error: true
       - name: Upload Reports
         if: failure()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Coverage Status](https://coveralls.io/repos/github/creek-service/ks-connected-services-demo/badge.svg?branch=main)](https://coveralls.io/github/creek-service/ks-connected-services-demo?branch=main)
+[![codecov](https://codecov.io/gh/creek-service/ks-connected-services-demo/branch/main/graph/badge.svg)](https://codecov.io/gh/creek-service/ks-connected-services-demo)
 [![build](https://github.com/creek-service/ks-connected-services-demo/actions/workflows/build.yml/badge.svg)](https://github.com/creek-service/ks-connected-services-demo/actions/workflows/build.yml)
 [![CodeQL](https://github.com/creek-service/ks-connected-services-demo/actions/workflows/codeql.yml/badge.svg)](https://github.com/creek-service/ks-connected-services-demo/actions/workflows/codeql.yml)
 
@@ -15,7 +15,7 @@ and associated [docs](docs/README.md).
 * `./gradlew format` will format the code using [Spotless][spotless].
 * `./gradlew static` will run static code analysis, i.e. [Spotbugs][spotbugs] and [Checkstyle][checkstyle].
 * `./gradlew check` will run all checks and tests.
-* `./gradlew coverage` will generate a cross-module [Jacoco][jacoco] coverage report.
+* `./gradlew jacocoTestReport` will generate [Jacoco][jacoco] coverage reports for each module.
 
 [spotless]: https://github.com/diffplug/spotless
 [spotbugs]: https://spotbugs.github.io/

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -40,7 +40,6 @@ kotlin {
 dependencies {
     implementation("com.github.spotbugs.snom:spotbugs-gradle-plugin:6.4.8")                // https://plugins.gradle.org/plugin/com.github.spotbugs
     implementation("com.diffplug.spotless:spotless-plugin-gradle:7.2.1")                   // https://plugins.gradle.org/plugin/com.diffplug.spotless
-    implementation("gradle.plugin.org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.12.2")   // https://plugins.gradle.org/plugin/com.github.kt3k.coveralls
     implementation("org.javamodularity:moduleplugin:1.8.15")                                // https://plugins.gradle.org/plugin/org.javamodularity.moduleplugin
     implementation("io.github.gradle-nexus:publish-plugin:2.0.0")                           // https://plugins.gradle.org/plugin/io.github.gradle-nexus.publish-plugin
     implementation("org.creekservice:creek-system-test-gradle-plugin:0.4.1")                // https://plugins.gradle.org/plugin/org.creekservice.system.test

--- a/buildSrc/src/main/kotlin/coverage-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/coverage-convention.gradle.kts
@@ -1,7 +1,5 @@
-import org.creekservice.api.system.test.gradle.plugin.coverage.SystemTestCoverageExtension
-
 /*
- * Copyright 2022-2023 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +15,9 @@ import org.creekservice.api.system.test.gradle.plugin.coverage.SystemTestCoverag
  */
 
 /**
- * Standard coverage configuration of Creek aggregates, utilising Jacoco and Coveralls.io
+ * Standard coverage configuration of Creek aggregates, utilising Jacoco and Codecov.
  *
- * <p>Version: 1.3
+ * <p>Version: 1.4
  *
  * <p>Apply to root project only
  */
@@ -27,7 +25,6 @@ import org.creekservice.api.system.test.gradle.plugin.coverage.SystemTestCoverag
 plugins {
     java
     jacoco
-    id("com.github.kt3k.coveralls")
     id("org.creekservice.system.test")
 }
 
@@ -38,48 +35,10 @@ repositories {
 allprojects {
     apply(plugin = "java")
 
-    tasks.withType<JacocoReport>().configureEach{
+    tasks.withType<JacocoReport>().configureEach {
         dependsOn(tasks.test)
-    }
-}
-
-val coverage = tasks.register<JacocoReport>("coverage") {
-    group = "creek"
-    description = "Generates an aggregate code coverage report"
-
-    val coverageReportTask = this
-
-    allprojects {
-        val proj = this
-        // Roll results of each test task into the main coverage task:
-        proj.tasks.matching { it.extensions.findByType<JacocoTaskExtension>() != null }.forEach {
-            coverageReportTask.sourceSets(proj.sourceSets.main.get())
-            coverageReportTask.executionData(it.extensions.findByType<JacocoTaskExtension>()!!.destinationFile)
-            coverageReportTask.dependsOn(it)
-        }
-
-        // Roll results for each system test task into the main coverage task:
-        proj.tasks.matching { it.extensions.findByType<SystemTestCoverageExtension>() != null }.forEach {
-            coverageReportTask.executionData(it.extensions.findByType<SystemTestCoverageExtension>()!!.destinationFile)
-            coverageReportTask.dependsOn(it)
+        reports {
+            xml.required.set(true)
         }
     }
-
-    reports {
-        xml.required.set(true)
-        html.required.set(true)
-    }
-}
-
-coveralls {
-    sourceDirs = allprojects.flatMap{it.sourceSets.main.get().allSource.srcDirs}.map{it.toString()}
-    jacocoReportPath = "$buildDir/reports/jacoco/coverage/coverage.xml"
-}
-
-tasks.coveralls {
-    group = "creek"
-    description = "Uploads the aggregated coverage report to Coveralls"
-
-    dependsOn(coverage)
-    onlyIf{System.getenv("CI") != null}
 }


### PR DESCRIPTION
Replaces Coveralls.io with Codecov for coverage reporting.

## Changes
- Remove `coveralls-gradle-plugin` from buildSrc dependencies
- Update `coverage-convention.gradle.kts`: remove coveralls plugin, remove multi-module aggregation task (Codecov handles merging natively), configure per-module JaCoCo XML reports
- Update `build.yml`: remove Coveralls env vars, run `jacocoTestReport` explicitly, add `codecov/codecov-action@v6.0.0`
- Update README: Codecov badge, update coverage Gradle task reference

The org-wide `CODECOV_TOKEN` secret is already configured.