### PR TITLE
chore(deps): bump codecov/codecov-action to v7.0.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Build
         run: ./gradlew build jacocoTestReport
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: '**/build/reports/jacoco/test/jacocoTestReport.xml'


### PR DESCRIPTION
## Summary
- Bump `codecov/codecov-action` from v6.x to v7.0.0
- This is needed to get CodeCov working again. Until this is merged, all builds can fail on the CodeCov step.

See: https://github.com/creek-service/creek-kafka/pull/918

🤖 Generated with [Claude Code](https://claude.com/claude-code)